### PR TITLE
fix id_rsa permissions only if present

### DIFF
--- a/import.js
+++ b/import.js
@@ -33,8 +33,8 @@ processConfig()
 
 util.copyDir(tmp, configDir)
 util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machine)
-// Fix file permissions for id_rsa key
-fs.chmodSync(path.join(configDir, 'id_rsa'), 0600)
+// Fix file permissions for id_rsa key, if present
+util.permissions(path.join(configDir, 'id_rsa'), 0600)
 fse.rmrfSync(tmp)
 
 

--- a/util.js
+++ b/util.js
@@ -36,3 +36,9 @@ exports.recurseJson = function (obj, func) {
         }
     }
 }
+
+exports.permissions = function (path, chmod) {
+    try {
+        fs.chmodSync(path, chmod)
+    } catch (e) {}
+}


### PR DESCRIPTION
I noticed that my imports were never working due to not having `id_rsa` on my backups, this PR fixes that

Refers to #5 
