### PR TITLE
Remove file extension only when present

### DIFF
--- a/import.js
+++ b/import.js
@@ -15,7 +15,7 @@ if (!machine) {
     process.exit(1)
 }
 
-var machine = machine.substring(0, machine.length - 4)
+var machine = machine.replace(/\.[^.]*$/, '')
 var configDir = process.env.HOME + '/.docker/machine/machines/' + machine
 try {
     fs.statSync(configDir)


### PR DESCRIPTION
If you name the machine to import without providing the extension then the old code will snip 4 characters off the end of the machine name.

Since the `.zip` extension is added to the name later it would be fine to just pass the machine name, if the behaviour was changed to only remove the extension when it exists. The regular expression used for removal matches the behaviour of the import.sh script (specifically `"${filename%.*}"`).
