### PR TITLE
Only copy certs folder when present

### DIFF
--- a/import.js
+++ b/import.js
@@ -32,7 +32,9 @@ unzip()
 processConfig()
 
 util.copyDir(tmp, configDir)
-util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machine)
+if (fs.existsSync(tmp + 'certs')) {
+    util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machine)
+}
 
 if (fs.existsSync(path.join(configDir, 'id_rsa'))) {
     // Fix file permissions for id_rsa key


### PR DESCRIPTION
If there are no machine specific certificates then the import of the machine will work but will end with an error:

```
➜ npm run import MACHINE.zip

importing.
fs.js:945
  return binding.readdir(pathModule._makeLong(path), options.encoding);
                 ^

Error: ENOENT: no such file or directory, scandir '/tmp/MACHINE/certs'
    at Error (native)
    at Object.fs.readdirSync (fs.js:945:18)
    at Object.exports.copyDir (.../machine-share/util.js:10:20)
    at Object.<anonymous> (.../machine-share/import.js:35:6)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.runMain (module.js:575:10)
```

This just checks for the existence of the folder before copying it.
