### PR TITLE
Only chmod rsa key when present

### DIFF
--- a/import.js
+++ b/import.js
@@ -33,8 +33,12 @@ processConfig()
 
 util.copyDir(tmp, configDir)
 util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machine)
-// Fix file permissions for id_rsa key
-fs.chmodSync(path.join(configDir, 'id_rsa'), 0600)
+
+if (fs.existsSync(path.join(configDir, 'id_rsa'))) {
+    // Fix file permissions for id_rsa key
+    fs.chmodSync(path.join(configDir, 'id_rsa'), 0600)
+}
+
 fse.rmrfSync(tmp)
 
 


### PR DESCRIPTION
It's possible to have a docker-machine that uses .pem files rather than id_rsa and id_rsa.pub. This skips the chmod when the id_rsa file does not exist.

It may actually be better to chmod any file in the folder.
