### PR TITLE
Windows support and cross platform import/export

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: http://editorconfig.org/
+# Please, read it!
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown make use of trailing whitespace, don't trim it!
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: 'standard',
+  rules: {
+    indent: [2, 2],
+  },
+};

--- a/export.js
+++ b/export.js
@@ -4,6 +4,7 @@ console.log('exporting.')
 
 var fs = require('fs')
 var path = require('path')
+var os = require('os');
 var fse = require('fs.extra')
 var zip = require('node-zip')
 var util = require('./util')
@@ -16,28 +17,28 @@ if (!machine) {
     process.exit(1)
 }
 
-var tmp = '/tmp/' + machine + '/'
+var tmp = path.join(os.tmpdir(), machine);
 fse.rmrfSync(tmp)
 
-var configDir = process.env.HOME + '/.docker/machine/machines/' + machine
+var configDir = path.join(process.env.HOME, '/.docker/machine/machines', machine)
 util.copyDir(configDir, tmp)
-fs.mkdirSync(tmp + 'certs')
+fs.mkdirSync(path.join(tmp, 'certs'))
 
 processConfig()
 createZip()
 
 function processConfig() {
     var home = process.env['HOME']
-    var configName = tmp + 'config.json';
+    var configName = path.join(tmp, 'config.json');
     var configFile = fs.readFileSync(configName)
     var config = JSON.parse(configFile.toString())
 
     util.recurseJson(config, function (parent, key, value) {
         if (typeof value === 'string') {
-            if (util.startsWith(value, home + '/.docker/machine/certs/')) {
-                var name = value.substring(value.lastIndexOf('/') + 1)
-                util.copy(value, tmp + 'certs/' + name)
-                value = home + '/.docker/machine/certs/' + machine + '/' + name
+            if (util.startsWith(value, path.join(home, '/.docker/machine/certs/'))) {
+                var name = path.basename(value)
+                util.copy(value, path.join(tmp, 'certs', name))
+                value = path.join(home, '/.docker/machine/certs', machine, name)
             }
             value = value.replace(home, '{{HOME}}')
             parent[key] = value

--- a/export.js
+++ b/export.js
@@ -9,6 +9,9 @@ var fse = require('fs.extra')
 var zip = require('node-zip')
 var util = require('./util')
 
+var DM_CERTS_DIR  = '/.docker/machine/certs/'
+var DM_MACHINE_DIR = '/.docker/machine/machines'
+
 var args = process.argv.slice(2)
 
 var machine = args[0]

--- a/export.js
+++ b/export.js
@@ -1,16 +1,15 @@
 #! /usr/bin/env node
-
 console.log('exporting.')
 
 var fs = require('fs')
 var path = require('path')
-var os = require('os');
+var os = require('os')
 var fse = require('fs.extra')
 var Zip = require('node-zip')
 var slash = require('slash')
 var util = require('./util')
 
-var DM_CERTS_DIR  = '/.docker/machine/certs/'
+var DM_CERTS_DIR = '/.docker/machine/certs/'
 var DM_MACHINE_DIR = '/.docker/machine/machines'
 var HOME = os.homedir()
 var TMP = os.tmpdir()
@@ -19,11 +18,11 @@ var args = process.argv.slice(2)
 
 var machine = args[0]
 if (!machine) {
-    console.log('machine-export <machine-name>')
-    process.exit(1)
+  console.log('machine-export <machine-name>')
+  process.exit(1)
 }
 
-var tmp = path.join(TMP, machine);
+var tmp = path.join(TMP, machine)
 fse.rmrfSync(tmp)
 
 var configDir = path.join(HOME, DM_MACHINE_DIR, machine)
@@ -33,39 +32,39 @@ fs.mkdirSync(path.join(tmp, 'certs'))
 processConfig()
 createZip()
 
-function processConfig() {
-    var configName = path.join(tmp, 'config.json');
-    var configFile = fs.readFileSync(configName)
-    var config = JSON.parse(configFile.toString())
+function processConfig () {
+  var configName = path.join(tmp, 'config.json')
+  var configFile = fs.readFileSync(configName)
+  var config = JSON.parse(configFile.toString())
 
-    util.recurseJson(config, function (parent, key, value) {
-        if (typeof value === 'string') {
-            if (util.startsWith(value, path.join(HOME, DM_CERTS_DIR))) {
-                var name = path.basename(value)
-                util.copy(value, path.join(tmp, 'certs', name))
-                value = path.join(HOME, DM_CERTS_DIR, machine, name)
-            }
-            value = value.replace(HOME, '{{HOME}}')
+  util.recurseJson(config, function (parent, key, value) {
+    if (typeof value === 'string') {
+      if (util.startsWith(value, path.join(HOME, DM_CERTS_DIR))) {
+        var name = path.basename(value)
+        util.copy(value, path.join(tmp, 'certs', name))
+        value = path.join(HOME, DM_CERTS_DIR, machine, name)
+      }
+      value = value.replace(HOME, '{{HOME}}')
             // uniform windows/unix paths
-            value = slash(value)
-            parent[key] = value
-        }
-    })
+      value = slash(value)
+      parent[key] = value
+    }
+  })
 
-    fs.writeFileSync(configName, JSON.stringify(config))
+  fs.writeFileSync(configName, JSON.stringify(config))
 }
 
-function createZip() {
-    var zip = new Zip()
-    var walker = fse.walk(tmp)
-    walker.on('file', function (root, stat, next) {
-        var dir = path.resolve(root, stat.name)
-        zip.folder(root.substring(tmp.length + 1)).file(stat.name, fs.readFileSync(dir).toString())
-        next()
-    });
-    walker.on('end', function () {
-        var data = zip.generate({base64: false, compression: 'DEFLATE'});
-        fs.writeFileSync(machine + '.zip', data, 'binary')
-        fse.rmrfSync(tmp)
-    })
+function createZip () {
+  var zip = new Zip()
+  var walker = fse.walk(tmp)
+  walker.on('file', function (root, stat, next) {
+    var dir = path.resolve(root, stat.name)
+    zip.folder(root.substring(tmp.length + 1)).file(stat.name, fs.readFileSync(dir).toString())
+    next()
+  })
+  walker.on('end', function () {
+    var data = zip.generate({base64: false, compression: 'DEFLATE'})
+    fs.writeFileSync(machine + '.zip', data, 'binary')
+    fse.rmrfSync(tmp)
+  })
 }

--- a/export.js
+++ b/export.js
@@ -7,6 +7,7 @@ var path = require('path')
 var os = require('os');
 var fse = require('fs.extra')
 var Zip = require('node-zip')
+var slash = require('slash')
 var util = require('./util')
 
 var DM_CERTS_DIR  = '/.docker/machine/certs/'
@@ -45,6 +46,8 @@ function processConfig() {
                 value = path.join(HOME, DM_CERTS_DIR, machine, name)
             }
             value = value.replace(HOME, '{{HOME}}')
+            // uniform windows/unix paths
+            value = slash(value)
             parent[key] = value
         }
     })

--- a/import.js
+++ b/import.js
@@ -63,7 +63,8 @@ function processConfig() {
 
     util.recurseJson(config, function (parent, key, value) {
         if (typeof value === 'string') {
-            parent[key] = value.replace('{{HOME}}', HOME)
+            // path.join fixes windows/unix paths
+            parent[key] = path.join(value.replace('{{HOME}}', HOME))
         }
     })
 

--- a/import.js
+++ b/import.js
@@ -15,7 +15,7 @@ if (!machine) {
     process.exit(1)
 }
 
-var machine = machine.substring(0, machine.length - 4)
+var machine = path.basename(machine.substring(0, machine.length - 4))
 var configDir = process.env.HOME + '/.docker/machine/machines/' + machine
 try {
     fs.statSync(configDir)

--- a/import.js
+++ b/import.js
@@ -9,6 +9,9 @@ var fse = require('fs.extra')
 var zip = require('node-zip')
 var util = require('./util')
 
+var DM_CERTS_DIR  = '/.docker/machine/certs/'
+var DM_MACHINE_DIR = '/.docker/machine/machines'
+
 var args = process.argv.slice(2)
 var machine = args[0]
 if (!machine) {
@@ -17,7 +20,7 @@ if (!machine) {
 }
 
 var machine = machine.substring(0, machine.length - 4)
-var configDir = path.join(process.env.HOME, '/.docker/machine/machines', machine)
+var configDir = path.join(process.env.HOME, DM_MACHINE_DIR, machine)
 try {
     fs.statSync(configDir)
     console.log('that machine already exists')
@@ -33,7 +36,7 @@ unzip()
 processConfig()
 
 util.copyDir(tmp, configDir)
-util.copyDir(path.join(tmp, 'certs'), path.join(process.env.HOME, '/.docker/machine/certs/', machine))
+util.copyDir(path.join(tmp, 'certs'), path.join(process.env.HOME, DM_CERTS_DIR, machine))
 // Fix file permissions for id_rsa key, if present
 util.permissions(path.join(configDir, 'id_rsa'), 0600)
 fse.rmrfSync(tmp)

--- a/import.js
+++ b/import.js
@@ -1,35 +1,32 @@
 #! /usr/bin/env node
-
 console.log('importing.')
 
 var fs = require('fs')
 var path = require('path')
-var os = require('os');
+var os = require('os')
 var fse = require('fs.extra')
 var Zip = require('node-zip')
 var util = require('./util')
 
-var DM_CERTS_DIR  = '/.docker/machine/certs/'
+var DM_CERTS_DIR = '/.docker/machine/certs/'
 var DM_MACHINE_DIR = '/.docker/machine/machines'
 var HOME = os.homedir()
 var TMP = os.tmpdir()
 
 var args = process.argv.slice(2)
-var machine = args[0]
-if (!machine) {
-    console.log('machine-import <config-zip>')
-    process.exit(1)
+var machineArg = args[0]
+if (!machineArg) {
+  console.log('machine-import <config-zip>')
+  process.exit(1)
 }
 
-var machine = machine.substring(0, machine.length - 4)
+var machine = machine.substring(0, machineArg.length - 4)
 var configDir = path.join(HOME, DM_MACHINE_DIR, machine)
 try {
-    fs.statSync(configDir)
-    console.log('that machine already exists')
-    process.exit(1)
-} catch (e) {
-    //ok
-}
+  fs.statSync(configDir)
+  console.log('that machine already exists')
+  process.exit(1)
+} catch (e) {}
 
 var tmp = path.join(TMP, machine)
 fse.rmrfSync(tmp)
@@ -40,48 +37,44 @@ processConfig()
 util.copyDir(tmp, configDir)
 util.copyDir(path.join(tmp, 'certs'), path.join(HOME, DM_CERTS_DIR, machine))
 // Fix file permissions for id_rsa key, if present
-util.permissions(path.join(configDir, 'id_rsa'), 0600)
+util.permissions(path.join(configDir, 'id_rsa'), '0600')
 fse.rmrfSync(tmp)
 
-
-function unzip() {
-    var zip = new Zip()
-    zip.load(fs.readFileSync(machine + '.zip'))
-    for (var f in zip.files) {
-        var file = zip.files[f]
-        if (!file.dir) {
-            util.mkdir(path.dirname(path.join(tmp, file.name)))
-            fs.writeFileSync(path.join(tmp, file.name), file.asNodeBuffer())
-        }
+function unzip () {
+  var zip = new Zip()
+  zip.load(fs.readFileSync(machine + '.zip'))
+  for (var f in zip.files) {
+    var file = zip.files[f]
+    if (!file.dir) {
+      util.mkdir(path.dirname(path.join(tmp, file.name)))
+      fs.writeFileSync(path.join(tmp, file.name), file.asNodeBuffer())
     }
+  }
 }
 
-function processConfig() {
-    var configName = path.join(tmp, 'config.json')
-    var configFile = fs.readFileSync(configName)
-    var config = JSON.parse(configFile.toString())
+function processConfig () {
+  var configName = path.join(tmp, 'config.json')
+  var configFile = fs.readFileSync(configName)
+  var config = JSON.parse(configFile.toString())
 
-    util.recurseJson(config, function (parent, key, value) {
-        if (typeof value === 'string') {
-            // path.join fixes windows/unix paths
-            parent[key] = path.join(value.replace('{{HOME}}', HOME))
-        }
-    })
-
-    var raw = config.RawDriver
-    if (raw) {
-        var decoded = new Buffer(raw, 'base64').toString()
-        var driver = JSON.parse(decoded)
-
-        // update store path
-        driver.StorePath = path.join(HOME, '/.docker/machine')
-
-        var updatedBlob = new Buffer(JSON.stringify(driver)).toString('base64')
-
-        // update old config
-        config.RawDriver = updatedBlob
+  util.recurseJson(config, function (parent, key, value) {
+    if (typeof value === 'string') {
+      // path.join fixes windows/unix paths
+      parent[key] = path.join(value.replace('{{HOME}}', HOME))
     }
+  })
 
+  var raw = config.RawDriver
+  if (raw) {
+    var decoded = new Buffer(raw, 'base64').toString()
+    var driver = JSON.parse(decoded)
+    // update store path
+    driver.StorePath = path.join(HOME, '/.docker/machine')
 
-    fs.writeFileSync(configName, JSON.stringify(config))
+    var updatedBlob = new Buffer(JSON.stringify(driver)).toString('base64')
+    // update old config
+    config.RawDriver = updatedBlob
+  }
+
+  fs.writeFileSync(configName, JSON.stringify(config))
 }

--- a/import.js
+++ b/import.js
@@ -32,11 +32,14 @@ unzip()
 processConfig()
 
 util.copyDir(tmp, configDir)
-util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machineName)
+
+if (fs.existsSync(tmp + 'certs')) {
+  util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machine)
+}
 
 if (fs.existsSync(path.join(configDir, 'id_rsa'))) {
-    // Fix file permissions for id_rsa key
-    fs.chmodSync(path.join(configDir, 'id_rsa'), 0600)
+  // Fix file permissions for id_rsa key
+  fs.chmodSync(path.join(configDir, 'id_rsa'), 0600)
 }
 
 fse.rmrfSync(tmp)

--- a/import.js
+++ b/import.js
@@ -33,8 +33,8 @@ processConfig()
 
 util.copyDir(tmp, configDir)
 util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machine)
-// Fix file permissions for id_rsa key
-fs.chmodSync(path.join(configDir, 'id_rsa'), 0600)
+// Fix file permissions for id_rsa key, if present
+util.permissions(path.join(configDir, 'id_rsa'), 0600)
 fse.rmrfSync(tmp)
 
 

--- a/import.js
+++ b/import.js
@@ -6,11 +6,13 @@ var fs = require('fs')
 var path = require('path')
 var os = require('os');
 var fse = require('fs.extra')
-var zip = require('node-zip')
+var Zip = require('node-zip')
 var util = require('./util')
 
 var DM_CERTS_DIR  = '/.docker/machine/certs/'
 var DM_MACHINE_DIR = '/.docker/machine/machines'
+var HOME = os.homedir()
+var TMP = os.tmpdir()
 
 var args = process.argv.slice(2)
 var machine = args[0]
@@ -20,7 +22,7 @@ if (!machine) {
 }
 
 var machine = machine.substring(0, machine.length - 4)
-var configDir = path.join(process.env.HOME, DM_MACHINE_DIR, machine)
+var configDir = path.join(HOME, DM_MACHINE_DIR, machine)
 try {
     fs.statSync(configDir)
     console.log('that machine already exists')
@@ -29,21 +31,21 @@ try {
     //ok
 }
 
-var tmp = path.join(os.tmpdir(), machine)
+var tmp = path.join(TMP, machine)
 fse.rmrfSync(tmp)
 
 unzip()
 processConfig()
 
 util.copyDir(tmp, configDir)
-util.copyDir(path.join(tmp, 'certs'), path.join(process.env.HOME, DM_CERTS_DIR, machine))
+util.copyDir(path.join(tmp, 'certs'), path.join(HOME, DM_CERTS_DIR, machine))
 // Fix file permissions for id_rsa key, if present
 util.permissions(path.join(configDir, 'id_rsa'), 0600)
 fse.rmrfSync(tmp)
 
 
 function unzip() {
-    var zip = new require('node-zip')()
+    var zip = new Zip()
     zip.load(fs.readFileSync(machine + '.zip'))
     for (var f in zip.files) {
         var file = zip.files[f]
@@ -55,14 +57,13 @@ function unzip() {
 }
 
 function processConfig() {
-    var home = process.env['HOME']
     var configName = path.join(tmp, 'config.json')
     var configFile = fs.readFileSync(configName)
     var config = JSON.parse(configFile.toString())
 
     util.recurseJson(config, function (parent, key, value) {
         if (typeof value === 'string') {
-            parent[key] = value.replace('{{HOME}}', home)
+            parent[key] = value.replace('{{HOME}}', HOME)
         }
     })
 
@@ -72,7 +73,7 @@ function processConfig() {
         var driver = JSON.parse(decoded)
 
         // update store path
-        driver.StorePath = path.join(process.env.HOME, '/.docker/machine')
+        driver.StorePath = path.join(HOME, '/.docker/machine')
 
         var updatedBlob = new Buffer(JSON.stringify(driver)).toString('base64')
 

--- a/import.js
+++ b/import.js
@@ -44,7 +44,7 @@ fse.rmrfSync(tmp)
 
 function unzip() {
     var zip = new require('node-zip')()
-    zip.load(fs.readFileSync(machine + '.zip'))
+    zip.load(fs.readFileSync(machine))
     for (var f in zip.files) {
         var file = zip.files[f]
         if (!file.dir) {

--- a/import.js
+++ b/import.js
@@ -15,8 +15,8 @@ if (!machine) {
     process.exit(1)
 }
 
-var machine = path.basename(machine.substring(0, machine.length - 4))
-var configDir = process.env.HOME + '/.docker/machine/machines/' + machine
+var machineName = path.basename(machine.substring(0, machine.length - 4))
+var configDir = process.env.HOME + '/.docker/machine/machines/' + machineName
 try {
     fs.statSync(configDir)
     console.log('that machine already exists')
@@ -25,14 +25,14 @@ try {
     //ok
 }
 
-var tmp = '/tmp/' + machine + '/'
+var tmp = '/tmp/' + machineName + '/'
 fse.rmrfSync(tmp)
 
 unzip()
 processConfig()
 
 util.copyDir(tmp, configDir)
-util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machine)
+util.copyDir(tmp + 'certs', process.env.HOME + '/.docker/machine/certs/' + machineName)
 
 if (fs.existsSync(path.join(configDir, 'id_rsa'))) {
     // Fix file permissions for id_rsa key

--- a/import.js
+++ b/import.js
@@ -20,7 +20,7 @@ if (!machineArg) {
   process.exit(1)
 }
 
-var machine = machine.substring(0, machineArg.length - 4)
+var machine = machineArg.substring(0, machineArg.length - 4)
 var configDir = path.join(HOME, DM_MACHINE_DIR, machine)
 try {
   fs.statSync(configDir)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-share",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "share docker machines with friendz",
   "bin": {
     "machine-export": "export.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "machine-import": "import.js"
   },
   "scripts": {
+    "eslint": "eslint *.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -33,5 +34,13 @@
     "node-zip": "^1.1.1",
     "slash": "^1.0.0",
     "tar": "^2.2.1"
-  }
+  },
+  "devDependencies": {
+    "eslint": "^3.8.1",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-promise": "^3.3.0",
+    "eslint-plugin-standard": "^2.0.1",
+    "pre-commit": "^1.1.3"
+  },
+  "pre-commit": ["eslint"],
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-share",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "share docker machines with friendz",
   "bin": {
     "machine-export": "export.js",
@@ -42,5 +42,5 @@
     "eslint-plugin-standard": "^2.0.1",
     "pre-commit": "^1.1.3"
   },
-  "pre-commit": ["eslint"],
+  "pre-commit": ["eslint"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-share",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "share docker machines with friendz",
   "bin": {
     "machine-export": "export.js",
@@ -29,6 +29,7 @@
     "fs.extra": "^1.3.2",
     "fstream": "^1.0.8",
     "jszip": "^2.5.0",
+    "mkdirp": "^0.5.1",
     "node-zip": "^1.1.1",
     "tar": "^2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-share",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "share docker machines with friendz",
   "bin": {
     "machine-export": "export.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machine-share",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "share docker machines with friendz",
   "bin": {
     "machine-export": "export.js",
@@ -31,6 +31,7 @@
     "jszip": "^2.5.0",
     "mkdirp": "^0.5.1",
     "node-zip": "^1.1.1",
+    "slash": "^1.0.0",
     "tar": "^2.2.1"
   }
 }

--- a/util.js
+++ b/util.js
@@ -2,39 +2,39 @@ var fs = require('fs')
 var mkdirp = require('mkdirp').sync
 
 exports.copy = function (from, to) {
-    var file = fs.readFileSync(from)
-    fs.writeFileSync(to, file)
+  var file = fs.readFileSync(from)
+  fs.writeFileSync(to, file)
 }
 
 exports.copyDir = function (from, to) {
-    mkdirp(to)
-    var files = fs.readdirSync(from)
-    for (var i = 0; i < files.length; i++) {
-        var file = from + '/' + files[i]
-        if (fs.statSync(file).isFile()) {
-            exports.copy(file, to + '/' + files[i])
-        }
+  mkdirp(to)
+  var files = fs.readdirSync(from)
+  for (var i = 0; i < files.length; i++) {
+    var file = from + '/' + files[i]
+    if (fs.statSync(file).isFile()) {
+      exports.copy(file, to + '/' + files[i])
     }
+  }
 }
 
 exports.mkdir = mkdirp
 
 exports.startsWith = function (s, prefix) {
-    return s.substring(0, prefix.length) === prefix
+  return s.substring(0, prefix.length) === prefix
 }
 
 exports.recurseJson = function (obj, func) {
-    for (var key in obj) {
-        var val = obj[key]
-        func(obj, key, val)
-        if (val !== null && typeof val === 'object') {
-            exports.recurseJson(val, func)
-        }
+  for (var key in obj) {
+    var val = obj[key]
+    func(obj, key, val)
+    if (val !== null && typeof val === 'object') {
+      exports.recurseJson(val, func)
     }
+  }
 }
 
 exports.permissions = function (path, chmod) {
-    try {
-        fs.chmodSync(path, chmod)
-    } catch (e) {}
+  try {
+    fs.chmodSync(path, chmod)
+  } catch (e) {}
 }

--- a/util.js
+++ b/util.js
@@ -1,4 +1,5 @@
 var fs = require('fs')
+var mkdirp = require('mkdirp').sync
 
 exports.copy = function (from, to) {
     var file = fs.readFileSync(from)
@@ -6,7 +7,7 @@ exports.copy = function (from, to) {
 }
 
 exports.copyDir = function (from, to) {
-    exports.mkdir(to)
+    mkdir(to)
     var files = fs.readdirSync(from)
     for (var i = 0; i < files.length; i++) {
         var file = from + '/' + files[i]
@@ -16,12 +17,7 @@ exports.copyDir = function (from, to) {
     }
 }
 
-exports.mkdir = function (dir) {
-    try {
-        fs.mkdirSync(dir)
-    } catch (e) {
-    }
-}
+exports.mkdir = mkdirp
 
 exports.startsWith = function (s, prefix) {
     return s.substring(0, prefix.length) === prefix

--- a/util.js
+++ b/util.js
@@ -36,3 +36,9 @@ exports.recurseJson = function (obj, func) {
         }
     }
 }
+
+exports.permissions = function (path, chmod) {
+    try {
+        fs.chmodSync(path, chmod)
+    } catch (e) {}
+}

--- a/util.js
+++ b/util.js
@@ -7,7 +7,7 @@ exports.copy = function (from, to) {
 }
 
 exports.copyDir = function (from, to) {
-    mkdir(to)
+    mkdirp(to)
     var files = fs.readdirSync(from)
     for (var i = 0; i < files.length; i++) {
         var file = from + '/' + files[i]


### PR DESCRIPTION
This is definitely an hard to merge PR, but I had to fix it for my own need.

The commits fixes different problems:
- windows support, it just _wasn't there_ because of not using platform-agnostic node API(s)
- cross-platform import/export. Path(s) now get exported in linux format, then during import they get adapted to the destination platform
- minimal styleguide to make this project more contributor-friendly
