### PR TITLE
File Intake check & ReadMe update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a small script that attempts to provide the missing import/export
 functionality in docker machine (see issue
 [23](https://github.com/docker/machine/issues/23))
 
-## installation 
+## installation
 
 ```
 npm install -g machine-share
@@ -14,14 +14,12 @@ npm install -g machine-share
 
 ```
 machine-export <machine-name>
->> exported to <machine-name>.tar 
+>> exported to <machine-name>.zip
 ```
 
 ## importing machines
 
 ```
-machine-import <machine-name>.tar
+machine-import <machine-name>.zip
 >> imported
 ```
-
-

--- a/import.js
+++ b/import.js
@@ -20,7 +20,15 @@ if (!machineArg) {
   process.exit(1)
 }
 
-var machine = machineArg.substring(0, machineArg.length - 4)
+// Make sure command points to a zip or tar file
+var file_type = machineArg.substring(machineArg.length - 4)
+var machine = ""
+if (!file_type.match(/^(.zip|.tar)$/)) {
+  machine = machineArg.substring(0, machineArg.length - 4)
+}
+machine = machineArg
+console.log('Using ', machineArg, " as file name")
+
 var configDir = path.join(HOME, DM_MACHINE_DIR, machine)
 try {
   fs.statSync(configDir)


### PR DESCRIPTION
Looks like current version in npm writes to zip, so just updated the ReadMe text as such. 

was having trouble as I kept forgetting to include the ".zip" of the machine name in the file type, so just added a check which grabs that off to set the machine name properly every time. It includes a check for a .tar file as well if we switch back to that file type. 